### PR TITLE
Add composer.json to describe the package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+	"name": "alleyinteractive/wp-updates-notifier",
+	"type": "wordpress-plugin",
+	"description": "WP Updates Notifier",
+	"homepage": "https://github.com/alleyinteractive/wp-updates-notifier",
+	"license": "GPL-2.0-or-later",
+	"authors": [
+		{
+			"name": "Alley",
+			"homepage": "https://alley.co/"
+		},
+		{
+			"name": "Scott Cariss",
+			"homepage": "https://scott.cariss.dev/"
+		}
+	],
+	"support": {
+		"issues": "https://github.com/alleyinteractive/wp-updates-notifier/issues",
+		"source": "https://github.com/alleyinteractive/wp-updates-notifier"
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"type": "wordpress-plugin",
 	"description": "WP Updates Notifier",
 	"homepage": "https://github.com/alleyinteractive/wp-updates-notifier",
-	"license": "GPL-2.0-or-later",
+	"license": "GPL-3.0-or-later",
 	"authors": [
 		{
 			"name": "Alley",


### PR DESCRIPTION
This PR adds a composer.json file that describes the package and sets its type to `wordpress-plugin`, which enables installation via Composer.